### PR TITLE
Fix code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -94,7 +94,12 @@ namespace RazorPagesTestSample.Pages
 
         public static void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath))
+            {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
     }


### PR DESCRIPTION
Fixes [https://github.com/sayedpfe/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/1](https://github.com/sayedpfe/TechExcel-Accelerate-developer-productivity-with-GitHub-Copilot-and-Dev-Box/security/code-scanning/1)

To fix the problem, we need to ensure that the paths derived from the zip archive entries are validated to prevent directory traversal attacks. This involves:
1. Using `Path.GetFullPath` to resolve any directory traversal elements in the combined path.
2. Ensuring that the resolved path is within the intended destination directory.

The steps to implement the fix are:
1. Combine the destination directory and the entry's full name using `Path.Combine`.
2. Resolve the combined path using `Path.GetFullPath`.
3. Resolve the destination directory path using `Path.GetFullPath`.
4. Check if the resolved file path starts with the resolved destination directory path.
5. If the check fails, throw an exception to prevent extraction.
6. If the check passes, proceed with extracting the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
